### PR TITLE
Commented out line capitalizing Pokémon name

### DIFF
--- a/Pokemon Shiny Tracker/Pokemon.cpp
+++ b/Pokemon Shiny Tracker/Pokemon.cpp
@@ -23,7 +23,7 @@ Pokemon::Pokemon() {
 //searches for file and pulls the data from the file with the corresponding name
 void Pokemon::generatePokemonData(std::string inputName) {
     char option;
-    inputName[0] = toupper(inputName[0]);
+    //inputName[0] = toupper(inputName[0]);
     if (inputName.compare("Basculin") == 0) {
         std::cout << "Are you hunting Blue or Red Stripe Basculin? B/R\n";
         option = getchar();


### PR DESCRIPTION
I think this was the issue with me on Linux not being able to move past the initial prompt for the Pokémon name. The files are titled the Pokémon names in lowercase and that line was making the first letter uppercase, so it couldn't find the right file.